### PR TITLE
include TBranch header

### DIFF
--- a/feGEMAnalyzer/feGEM_module.cxx
+++ b/feGEMAnalyzer/feGEM_module.cxx
@@ -10,6 +10,7 @@
 #include "GEM_BANK_flow.h"
 
 #include "TTree.h"
+#include "TBranch.h"
 
 #include "manalyzer.h"
 #include "midasio.h"


### PR DESCRIPTION
fix:
ROOT/TIOFeatures.hxx:17:7: note: forward declaration of ‘class TBranch’

I'm using gcc8.3